### PR TITLE
On test failure: Fix to show the stacktrace

### DIFF
--- a/nosetests.xslt
+++ b/nosetests.xslt
@@ -124,7 +124,7 @@
                         <pre><b>Test Name:</b> <xsl:value-of select="@name"/></pre>
                         <pre><b>Running Time:</b> <xsl:value-of select="@time"/></pre>
                         <pre><b>State:</b><a>Failed</a></pre>
-                        <xsl:for-each select="system-out">
+                        <xsl:for-each select="failure">
                             <div class="error-message">
                                 <pre><a class="display-message"> Error Message</a></pre>
                                 <xsl:value-of select="."/>


### PR DESCRIPTION
using nosetests:  version 1.3.7

with a general usage of nose assertions like following, depending on "system-out" doesn't work:
<img width="485" alt="screen shot 2016-12-01 at 6 11 58 pm" src="https://cloud.githubusercontent.com/assets/6470509/20794311/ad03ce6c-b7f1-11e6-8de3-08011ec9001b.png">
**Reason:**
the nosetests.xml stores stacktrace under "failure" tag 

**After this fix:**
<img width="1341" alt="screen shot 2016-12-01 at 6 14 21 pm" src="https://cloud.githubusercontent.com/assets/6470509/20794378/0217c778-b7f2-11e6-83ba-6b5443eb7622.png">
**Before fix:**
<img width="715" alt="screen shot 2016-12-01 at 6 15 07 pm" src="https://cloud.githubusercontent.com/assets/6470509/20794397/1ddc87a0-b7f2-11e6-846f-a215ac06f821.png">

